### PR TITLE
docs(context): recover portfolio context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+<!-- portfolio-context:start -->
+# Portfolio Context
+
+## What This Project Is
+
+`app` is an intentionally stopped SwiftUI/Xcode template repo kept as a record, not a product in flight. The generic name and location under `Misc:NoGoPRJs` are part of the signal: no product hypothesis survived beyond the default scaffold.
+
+## Current State
+
+`STATUS.md` confirms a scaffold stop: `ContentView.swift` is intact, no restore is needed, and the row should not be treated as active product work unless a new written hypothesis arrives and the repo is renamed.
+
+## Stack
+
+| Layer | Technology |
+|-------|------------|
+| Language | Swift 5.0 |
+| UI Framework | SwiftUI |
+| Minimum Target | iOS 26.2 |
+| Supported Devices | iPhone, iPad, Apple Vision Pro |
+| Build Tool | Xcode 16+ |
+
+> **Status: Work in Progress** — Project structure established; core implementation in progress.
+
+## How To Run
+
+```bash
+git clone https://github.com/saagpatel/app.git
+cd app
+open app.xcodeproj
+```
+
+Select the `app` scheme in Xcode, choose a Simulator or connected device running iOS 26.2+, and press Run.
+
+## Known Risks
+
+- Do not treat this repo as active implementation work without first satisfying the reactivation criteria in `STATUS.md`.
+- The README still describes the generic Xcode scaffold and may overstate "work in progress"; `STATUS.md` is the stronger source of truth.
+- If reactivated, rename the repo before adding product code.
+
+## Next Recommended Move
+
+Leave this row parked unless the operator supplies a concrete product hypothesis that is not better served by an existing iOS app in the portfolio.
+
+<!-- portfolio-context:end -->


### PR DESCRIPTION
## Summary
- add a managed Portfolio Context block to the repo handoff file
- capture project purpose, current state, stack, run notes, risks, and next move for Arc H context recovery

## Verification
- Generated by GithubRepoAuditor context recovery batch 8
- Focused Arc H verification passed in GithubRepoAuditor: tests/test_portfolio_context_triage.py tests/test_context_quality.py tests/test_catalog_validator.py tests/test_cli_subcommands.py